### PR TITLE
Potential fix for code scanning alert no. 112: Incomplete regular expression for hostnames

### DIFF
--- a/backend/lib/openzeppelin-contracts/certora/run.js
+++ b/backend/lib/openzeppelin-contracts/certora/run.js
@@ -101,7 +101,7 @@ async function runCertora(spec, contract, files, options = []) {
   stream.end();
 
   // write results in markdown format
-  writeEntry(spec, contract, code || signal, (await output).match(/https:\/\/prover.certora.com\/output\/\S*/)?.[0]);
+  writeEntry(spec, contract, code || signal, (await output).match(/https:\/\/prover\.certora\.com\/output\/\S*/)?.[0]);
 
   // write all details
   console.error(`+ certoraRun ${args.join(' ')}\n` + (await output));


### PR DESCRIPTION
Potential fix for [https://github.com/th30d4y/OpenLearnX/security/code-scanning/112](https://github.com/th30d4y/OpenLearnX/security/code-scanning/112)

To fix this, escape literal dots in the hostname portion of the regex so it matches only `prover.certora.com` exactly.

Best single change (without altering functionality) is in `backend/lib/openzeppelin-contracts/certora/run.js` at line 104: replace  
`/https:\/\/prover.certora.com\/output\/\S*/`  
with  
`/https:\/\/prover\.certora\.com\/output\/\S*/`.

No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
